### PR TITLE
Cowsay should be disabled by default

### DIFF
--- a/fortune-cookie.el
+++ b/fortune-cookie.el
@@ -52,7 +52,7 @@ Defaults to the first on your path."
   :type 'string
   :group 'fortune-cookie)
 
-(defcustom fortune-cookie-cowsay-enable t
+(defcustom fortune-cookie-cowsay-enable nil
   "Pipes `fortune' through `cowsay' if true."
   :type 'boolean
   :group 'fortune-cookie)


### PR DESCRIPTION
For consistency, I think cowsay should be disabled by default. 

This package should only assume that users have the fortune program installed, and not any additional packages.